### PR TITLE
Bump Bigtable client version to the the snapshot from 10/29/2015

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-1.0</artifactId>
-      <version>0.1.9</version>
+      <version>0.2.2-20151029.111903-12</version>
     </dependency>
 
     <dependency>
@@ -234,7 +234,7 @@
 
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
+      <artifactId>netty-all</artifactId>
       <version>4.1.0.Beta5</version>
     </dependency>
 


### PR DESCRIPTION
to include the rowfilter regex support.
Also add netty-all
