### PR TITLE
Add the commons-lang dependency required by the HBase metrics library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,12 @@
       <version>1.7.7</version>
       <scope>runtime</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
 
     <!-- test dependencies -->
 


### PR DESCRIPTION
that isn't pulled in by the Bigtable client. TODO - fix it upstream.
