### PR TITLE
Update rest of the methods to use Netty 4

### DIFF
--- a/src/main/java/org/hbase/async/FilterList.java
+++ b/src/main/java/org/hbase/async/FilterList.java
@@ -26,7 +26,7 @@
  */
 package org.hbase.async;
 
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +100,7 @@ public final class FilterList extends ScanFilter {
   }
 
   @Override
-  void serializeOld(final ChannelBuffer buf) {
+  void serializeOld(final ByteBuf buf) {
     buf.writeByte((byte) NAME.length);   // 1
     buf.writeBytes(NAME);                //41
     buf.writeByte((byte) op.ordinal());  // 1

--- a/src/main/java/org/hbase/async/FuzzyRowFilter.java
+++ b/src/main/java/org/hbase/async/FuzzyRowFilter.java
@@ -26,7 +26,7 @@
  */
 package org.hbase.async;
 
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
 
 import java.lang.IllegalArgumentException;
 import java.util.Collection;
@@ -142,7 +142,7 @@ public final class FuzzyRowFilter extends ScanFilter {
   }
 
   @Override
-  void serializeOld(ChannelBuffer buf) {
+  void serializeOld(ByteBuf buf) {
     
   }
 

--- a/src/main/java/org/hbase/async/KeyRegexpFilter.java
+++ b/src/main/java/org/hbase/async/KeyRegexpFilter.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
 
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
@@ -160,7 +160,7 @@ public final class KeyRegexpFilter extends ScanFilter {
   }
 
   @Override
-  void serializeOld(final ChannelBuffer buf) {
+  void serializeOld(final ByteBuf buf) {
     buf.writeByte((byte) ROWFILTER.length);                     // 1
     buf.writeBytes(ROWFILTER);                                  // 40
     // writeUTF of the comparison operator

--- a/src/main/java/org/hbase/async/ScanFilter.java
+++ b/src/main/java/org/hbase/async/ScanFilter.java
@@ -26,7 +26,7 @@
  */
 package org.hbase.async;
 
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
 
 /**
  * Abstract base class for {@link org.hbase.async.Scanner} filters.
@@ -70,7 +70,7 @@ public abstract class ScanFilter {
    * This method is only used with HBase 0.94 and before.
    * @param buf The RPC channel buffer to which the byte array is serialized
    */
-  abstract void serializeOld(ChannelBuffer buf);
+  abstract void serializeOld(ByteBuf buf);
 
   /**
    * returns the number of bytes that it will write to the RPC channel buffer when {@code serialize}


### PR DESCRIPTION
Based on https://github.com/OpenTSDB/asyncbigtable/commit/4f39af48be15768e89395fbb786588d5c4bcc5fc

Fixes the following errors:
```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] asyncbigtable/src/main/java/org/hbase/async/ScanFilter.java:[29,29] error: package org.jboss.netty.buffer does not exist
[ERROR] asyncbigtable/src/main/java/org/hbase/async/ScanFilter.java:[73,29] error: cannot find symbol
[ERROR]   symbol:   class ChannelBuffer
  location: class ScanFilter
asyncbigtable/src/main/java/org/hbase/async/KeyRegexpFilter.java:[34,29] error: package org.jboss.netty.buffer does not exist
[ERROR] asyncbigtable/src/main/java/org/hbase/async/KeyRegexpFilter.java:[35,27] error: package org.jboss.netty.util does not exist
[ERROR] asyncbigtable/src/main/java/org/hbase/async/KeyRegexpFilter.java:[163,26] error: cannot find symbol
[ERROR]   symbol:   class ChannelBuffer
  location: class KeyRegexpFilter
asyncbigtable/src/main/java/org/hbase/async/FilterList.java:[29,29] error: package org.jboss.netty.buffer does not exist
[ERROR] asyncbigtable/src/main/java/org/hbase/async/FilterList.java:[103,26] error: cannot find symbol
[ERROR]   symbol:   class ChannelBuffer
  location: class FilterList
asyncbigtable/src/main/java/org/hbase/async/FuzzyRowFilter.java:[29,29] error: package org.jboss.netty.buffer does not exist
[ERROR] asyncbigtable/src/main/java/org/hbase/async/FuzzyRowFilter.java:[145,20] error: cannot find symbol
[INFO] 9 errors 
[INFO] -------------------------------------------------------------
```