### PR TITLE
Update deps to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>com.stumbleupon</groupId>
       <artifactId>async</artifactId>
-      <version>1.4.0</version>
+      <version>1.4.1</version>
     </dependency>
 
     <dependency>
@@ -222,20 +222,26 @@
 
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.1</artifactId>
-      <version>0.9.5.1</version>
+      <artifactId>bigtable-hbase-1.2</artifactId>
+      <version>0.9.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>1.1.33.Fork26</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.0.0-alpha-3.1</version>
+      <version>3.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.0.Beta5</version>
+      <version>4.1.0.Final</version>
     </dependency>
 
     <!-- runtime dependencies -->


### PR DESCRIPTION
Since `com.google.cloud.bigtable` has been updated to the latest stable `0.9.5.1` it makes sense to update the following:
* Use `com.google.cloud.bigtable` artifact as specified [upstream](https://github.com/GoogleCloudPlatform/cloud-bigtable-client#using-the-java-client)
* Update `protobuf-java` from alpha `3.0.0` to [final release](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/3.0.0)
* Update `netty-all` from beta `4.1.0` to [final release](https://mvnrepository.com/artifact/io.netty/netty-all/4.1.0.Final)
* Update `async` from `1.4.0` to latest `1.4.1`

Sucessfully built `asyncbigtable-0.2.1-SNAPSHOT-jar-with-dependencies.jar` with these changes:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:36 min
[INFO] Finished at: 2017-04-17T17:26:07+02:00
[INFO] Final Memory: 188M/452M
[INFO] ------------------------------------------------------------------------
```
