### PR TITLE
Using async bigtable methods instead of HBase methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,29 @@
         </plugins>
       </build>
     </profile>
-
+    <!-- The Configuration of the integration-test profile -->
+    <profile>
+      <id>bt-integration-test</id>
+      <properties>
+          <build.profile.id>bt-integration-test</build.profile.id>
+      </properties>
+      <build>
+        <plugins>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.18.1</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -185,16 +207,15 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 
   <dependencies>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-1.x</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>
@@ -209,23 +230,6 @@
       <version>1.7.7</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.x</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>4.1.0.Final</version>
-    </dependency>
 
     <!-- runtime dependencies -->
 
@@ -235,7 +239,7 @@
       <version>1.7.7</version>
       <scope>runtime</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
@@ -246,26 +250,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>1.10</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-auth</artifactId>
-      <version>2.5.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.directory.server</groupId>
-          <artifactId>apacheds-kerberos-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- test dependencies -->

--- a/src/main/java/org/hbase/async/DeleteRequest.java
+++ b/src/main/java/org/hbase/async/DeleteRequest.java
@@ -52,7 +52,7 @@ public final class DeleteRequest extends BatchableRpc
     new byte[][] { HBaseClient.EMPTY_ARRAY };
 
   /** Special value for {@link #family} when deleting a whole row.  */
-  static final byte[] WHOLE_ROW = new byte[0];
+  static final byte[] WHOLE_ROW = null;
 
   private final byte[][] qualifiers;
 

--- a/src/test/java/org/hbase/async/DataGenerationHelper.java
+++ b/src/test/java/org/hbase/async/DataGenerationHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017  The Async BigTable Authors.  All rights reserved.
+ * This file is part of Async BigTable.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * Methods to generate test data.
+ */
+public class DataGenerationHelper {
+
+  public byte[] randomData(String prefix) {
+    return randomData(prefix, "");
+  }
+
+  public byte[] randomData(String prefix, String suffix) {
+    return Bytes.toBytes(randomString(prefix, suffix));
+  }
+
+  public String randomString(String prefix) {
+    return randomString(prefix, "");
+  }
+
+  public String randomString(String prefix, String suffix) {
+    return prefix + RandomStringUtils.randomAlphanumeric(8) + suffix;
+  }
+
+  public byte[][] randomData(String prefix, int count) {
+    byte[][] result = new byte[count][];
+    for (int i = 0; i < count; ++i) {
+      result[i] = Bytes.toBytes(prefix + RandomStringUtils.randomAlphanumeric(8));
+    }
+    return result;
+  }
+}

--- a/src/test/java/org/hbase/async/HBaseClientIT.java
+++ b/src/test/java/org/hbase/async/HBaseClientIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 The Async BigTable Authors.  All rights reserved.
+ * This file is part of Async BigTable.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */package org.hbase.async;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.shaded.org.junit.AfterClass;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class HBaseClientIT {
+
+  private static TableName TABLE_NAME =
+      TableName.valueOf("test_table-" + UUID.randomUUID().toString());
+  private static byte[] FAMILY = Bytes.toBytes("cf");
+  private static final DataGenerationHelper dataHelper = new DataGenerationHelper();
+
+  @BeforeClass
+  public static void createTable() throws IOException {
+    Admin admin = TestingUtil.getClient().getHbaseConnection().getAdmin();
+    try {
+      admin.createTable(
+        new HTableDescriptor(TABLE_NAME)
+          .addFamily(new HColumnDescriptor(FAMILY)));
+    } finally {
+      admin.close();
+    }
+  }
+
+  @AfterClass
+  public static void deleteTable() throws IOException {
+    Admin admin = TestingUtil.getClient().getHbaseConnection().getAdmin();
+    try {
+      admin.deleteTable(TABLE_NAME);
+    } finally {
+      admin.close();
+    }
+  }
+
+  private HBaseClient client;
+
+  @Before
+  public void setup() {
+    client = TestingUtil.getClient();
+  }
+
+  /**
+   * Really basic test to make sure that put, get and delete work.
+   */
+  @Test
+  public void testBasics() throws Exception {
+    byte[] rowKey = dataHelper.randomData("putKey-");
+    byte[] qualifier = Bytes.toBytes("qual");
+    byte[] value = dataHelper.randomData("value-");
+
+    // Write the value, and make sure it's written
+    client.put(new PutRequest(TABLE_NAME.getName(), rowKey, FAMILY, qualifier, value));
+    client.flush().join();
+
+    // Make sure that the value is as expected
+    assertGetEquals(rowKey, qualifier, value);
+
+    // Delete the value
+    client.delete(new DeleteRequest(TABLE_NAME.getName(), rowKey)).join();
+
+    // Make sure that the value is deleted
+    Assert.assertEquals(0, get(rowKey).size());
+  }
+
+  @Test
+  public void testAppend() throws Exception {
+    byte[] rowKey = dataHelper.randomData("appendKey-");
+    byte[] qualifier = dataHelper.randomData("qualifier-");
+    byte[] value1 = dataHelper.randomData("value1-");
+    byte[] value2 = dataHelper.randomData("value1-");
+    byte[] value1And2 = ArrayUtils.addAll(value1, value2);
+    
+    // Write the value, and make sure it's written
+    client.put(new PutRequest(TABLE_NAME.getName(), rowKey, FAMILY, qualifier, value1));
+    client.flush().join();
+
+    client
+        .append(
+          new AppendRequest(TABLE_NAME.getName(), new KeyValue(rowKey, FAMILY, qualifier, value2)))
+        .join();
+    
+    ArrayList<KeyValue> response = get(rowKey);
+    Assert.assertEquals(1, response.size());
+    Assert.assertTrue(Bytes.equals(value1And2, response.get(0).value()));
+  }
+
+  private void assertGetEquals(byte[] key, byte[] qual, byte[] val)
+      throws Exception {
+    ArrayList<KeyValue> response = get(key);
+    Assert.assertEquals(1, response.size());
+    KeyValue result = response.get(0);
+
+    Assert.assertTrue(Bytes.equals(FAMILY, result.family()));
+    Assert.assertTrue(Bytes.equals(qual, result.qualifier()));
+    Assert.assertTrue(Bytes.equals(val, result.value()));
+  }
+
+  private ArrayList<KeyValue> get(byte[] key) throws Exception {
+    return client.get(new GetRequest(TABLE_NAME.getName(), key)).join();
+  }
+}

--- a/src/test/java/org/hbase/async/TestingUtil.java
+++ b/src/test/java/org/hbase/async/TestingUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017  The Async BigTable Authors.  All rights reserved.
+ * This file is part of Async BigTable.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the StumbleUpon nor the names of its contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hbase.async;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+
+public class TestingUtil {
+
+  private static HBaseClient client;
+
+  public synchronized static HBaseClient getClient() {
+    if (client == null) {
+      client = new HBaseClient(getConfiguration(),
+          BigtableSessionSharedThreadPools.getInstance().getBatchThreadPool());
+    }
+    return client;
+  }
+
+  private static Configuration getConfiguration() {
+    String projectId = System.getProperty("google.bigtable.project.id");
+    String instanceId = System.getProperty("google.bigtable.instance.id");
+    return BigtableConfiguration.configure(projectId, instanceId);
+  }
+
+}


### PR DESCRIPTION
The Cloud Bigtable client is inherently async under the covers.  Conver use of BufferedMutator and other methods to better take advantage of the underlying Cloud Bigtable async features.
Added an integration test that tests basic functionality.  As part of that testing, issue #29 was fixed.
Here's the command line To run the new integration tests:

`mvn clean verify -Pbt-integration-test -Dgoogle.bigtable.project.id={projectId} -Dgoogle.bigtable.instance.id={instanceId}`

I'll get one of my coworkers to review this change.