### PR TITLE
Upgrading java version to 1.8, and CBT to 1.2.0 in prepartion to migate to Hbase 2.0 async api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,8 +183,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerArgument>-Xlint</compilerArgument>
         </configuration>
       </plugin>
@@ -227,9 +227,9 @@
 
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.x</artifactId>
-      <version>1.0.0</version>
-    </dependency>
+      <artifactId>bigtable-hbase-2.x</artifactId>
+      <version>1.2.0</version>
+     </dependency>
 
     <!-- runtime dependencies -->
 


### PR DESCRIPTION
Initial PR to migrate to new bigtable hbase 2.x API, which supports asynchronous operations using Java 8 CompletableFuture. 