### PR TITLE
Replace Bigtable/Hbase Connection with AsyncConnection

### DIFF
--- a/src/main/java/org/hbase/async/Scanner.java
+++ b/src/main/java/org/hbase/async/Scanner.java
@@ -26,27 +26,22 @@
  */
 package org.hbase.async;
 
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
-
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.filter.ByteArrayComparable;
-import org.apache.hadoop.hbase.filter.CompareFilter;
-import org.apache.hadoop.hbase.filter.RegexStringComparator;
-import org.apache.hadoop.hbase.filter.RowFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.NavigableMap;
 
-import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
+import org.apache.hadoop.hbase.client.AsyncTable;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
 
 /**
  * Creates a scanner to read data sequentially from BigTable.
@@ -96,7 +91,7 @@ public final class Scanner {
   private ResultScanner result_scanner;
 
   /** The HBase table object we're working on */
-  private Table hbase_client_table;
+  private AsyncTable hbase_client_table;
 
   /**
    * The default maximum number of {@link KeyValue}s the server is allowed
@@ -717,12 +712,12 @@ public final class Scanner {
   }
 
   /** @return the HTable client */
-  Table getHbaseTable() {
+  AsyncTable getHbaseTable() {
     return hbase_client_table;
   }
 
   /** @param table The HTable client object */
-  public void setHbaseTable(final Table table) {
+  public void setHbaseTable(final AsyncTable table) {
     this.hbase_client_table = table;
   }
 


### PR DESCRIPTION
mutator_flush_interval configuration has a very noticeable impact on performance. 1sec and less performed optimally. At 5 seconds it was degraded and uneven.

Passing these settings increased the performance in tests from 300k writes to over 400k
google.bigtable.grpc.channel.count = 50
google.bigtable.bulk.max.row.key.count = 1000
google.bigtable.buffered.mutator.max.inflight.rpcs = 1000

Enabling appends performs better (and does not need additional storage compaction)
tsd.stoarge.enable_appends = true
tsd.storage.use_otsdb_timestamp = false

Setting tsd.core.meta.enable_tsuid_tracking = true degrades the performance by around 20x. Moving to async connection improved the performance here by 3x from before, but clearly not enough.
For better perfomance with this setting, most probably work is needed in TSDB to move to a model like checkAndIncrement, instead of the current read followed by write callback chain approach.
 