### PR TITLE
Converting more calls to asyncConnection API

### DIFF
--- a/src/main/java/org/hbase/async/Scanner.java
+++ b/src/main/java/org/hbase/async/Scanner.java
@@ -26,22 +26,27 @@
  */
 package org.hbase.async;
 
-import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.filter.CompareFilter;
+import org.apache.hadoop.hbase.filter.RegexStringComparator;
+import org.apache.hadoop.hbase.filter.RowFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.NavigableMap;
 
-import org.apache.hadoop.hbase.client.AsyncTable;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
+import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
 
 /**
  * Creates a scanner to read data sequentially from BigTable.
@@ -91,7 +96,7 @@ public final class Scanner {
   private ResultScanner result_scanner;
 
   /** The HBase table object we're working on */
-  private AsyncTable hbase_client_table;
+  private Table hbase_client_table;
 
   /**
    * The default maximum number of {@link KeyValue}s the server is allowed
@@ -712,12 +717,12 @@ public final class Scanner {
   }
 
   /** @return the HTable client */
-  AsyncTable getHbaseTable() {
+  Table getHbaseTable() {
     return hbase_client_table;
   }
 
   /** @param table The HTable client object */
-  public void setHbaseTable(final AsyncTable table) {
+  public void setHbaseTable(final Table table) {
     this.hbase_client_table = table;
   }
 

--- a/src/main/java/org/hbase/async/Scanner.java
+++ b/src/main/java/org/hbase/async/Scanner.java
@@ -26,27 +26,22 @@
  */
 package org.hbase.async;
 
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
-
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.filter.ByteArrayComparable;
-import org.apache.hadoop.hbase.filter.CompareFilter;
-import org.apache.hadoop.hbase.filter.RegexStringComparator;
-import org.apache.hadoop.hbase.filter.RowFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.NavigableMap;
 
-import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
+import org.apache.hadoop.hbase.client.AsyncTable;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
 
 /**
  * Creates a scanner to read data sequentially from BigTable.
@@ -96,7 +91,7 @@ public final class Scanner {
   private ResultScanner result_scanner;
 
   /** The HBase table object we're working on */
-  private Table hbase_client_table;
+  private AsyncTable hbase_client_table;
 
   /**
    * The default maximum number of {@link KeyValue}s the server is allowed
@@ -717,12 +712,12 @@ public final class Scanner {
   }
 
   /** @return the HTable client */
-  Table getHbaseTable() {
+  AsyncTable getHbaseTable() {
     return hbase_client_table;
   }
 
   /** @param table The HTable client object */
-  public void setHbaseTable(final Table table) {
+  public void setHbaseTable(final AsyncTable table) {
     this.hbase_client_table = table;
   }
 

--- a/src/test/java/org/hbase/async/HBaseClientIT.java
+++ b/src/test/java/org/hbase/async/HBaseClientIT.java
@@ -159,7 +159,9 @@ public class HBaseClientIT {
     assertGetEquals(rowKey, qualifier, value);
 
     // Delete the value
-    client.delete(new DeleteRequest(TABLE_NAME.getName(), rowKey)).join();
+    Deferred<Object> deferredDelete = client.delete(new DeleteRequest(TABLE_NAME.getName(), rowKey));
+    client.flush().join();
+    deferredDelete.join();
 
     // Make sure that the value is deleted
     Assert.assertEquals(0, get(rowKey).size());


### PR DESCRIPTION
openScanner(), atomicIncrement, compareAndSet() and delete() calls.

This leaves only ensureTableFamilyExists() still using old connection. We will need another cbt-client jar release to address it.