### PR TITLE
Change append call to use Mutator, and Scanner to use AsyncTable.

### DIFF
--- a/src/main/java/org/hbase/async/HBaseClient.java
+++ b/src/main/java/org/hbase/async/HBaseClient.java
@@ -989,7 +989,6 @@ public final class HBaseClient {
     AsyncTable table = hbase_asyncConnection.getTable(TableName.valueOf(scanner.table()), executor);
     ResultScanner result = table.getScanner(scanner.getHbaseScan());
     scanner.setResultScanner(result);
-    scanner.setHbaseTable(table);
     return Deferred.fromResult(new Object());
   }
 
@@ -1014,7 +1013,6 @@ public final class HBaseClient {
       return Deferred.fromError(e);
     } finally {
       scanner.setResultScanner(null);
-      scanner.setHbaseTable(null);
     }
   }
 

--- a/src/main/java/org/hbase/async/Scanner.java
+++ b/src/main/java/org/hbase/async/Scanner.java
@@ -29,6 +29,7 @@ package org.hbase.async;
 import com.stumbleupon.async.Callback;
 import com.stumbleupon.async.Deferred;
 
+import org.apache.hadoop.hbase.client.AsyncTable;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -96,7 +97,7 @@ public final class Scanner {
   private ResultScanner result_scanner;
 
   /** The HBase table object we're working on */
-  private Table hbase_client_table;
+  private AsyncTable hbase_client_table;
 
   /**
    * The default maximum number of {@link KeyValue}s the server is allowed
@@ -717,12 +718,12 @@ public final class Scanner {
   }
 
   /** @return the HTable client */
-  Table getHbaseTable() {
+  AsyncTable getHbaseTable() {
     return hbase_client_table;
   }
 
   /** @param table The HTable client object */
-  public void setHbaseTable(final Table table) {
+  public void setHbaseTable(final AsyncTable table) {
     this.hbase_client_table = table;
   }
 

--- a/src/main/java/org/hbase/async/Scanner.java
+++ b/src/main/java/org/hbase/async/Scanner.java
@@ -26,28 +26,21 @@
  */
 package org.hbase.async;
 
-import com.stumbleupon.async.Callback;
-import com.stumbleupon.async.Deferred;
-
-import org.apache.hadoop.hbase.client.AsyncTable;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.filter.ByteArrayComparable;
-import org.apache.hadoop.hbase.filter.CompareFilter;
-import org.apache.hadoop.hbase.filter.RegexStringComparator;
-import org.apache.hadoop.hbase.filter.RowFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.NavigableMap;
 
-import static org.hbase.async.HBaseClient.EMPTY_ARRAY;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
 
 /**
  * Creates a scanner to read data sequentially from BigTable.
@@ -95,9 +88,6 @@ public final class Scanner {
    * HBase API ResultScanner. After the scan is submitted is must not be null.
    */
   private ResultScanner result_scanner;
-
-  /** The HBase table object we're working on */
-  private AsyncTable hbase_client_table;
 
   /**
    * The default maximum number of {@link KeyValue}s the server is allowed
@@ -715,16 +705,6 @@ public final class Scanner {
   /** @param result_scanner The scanner result object */
   void setResultScanner(final ResultScanner result_scanner) {
     this.result_scanner = result_scanner;
-  }
-
-  /** @return the HTable client */
-  AsyncTable getHbaseTable() {
-    return hbase_client_table;
-  }
-
-  /** @param table The HTable client object */
-  public void setHbaseTable(final AsyncTable table) {
-    this.hbase_client_table = table;
   }
 
   /**


### PR DESCRIPTION
Using Mutator avoids hang-up due to max cpu, by throttling the number of
in-flight async calls.