### PR TITLE
Updating to bigtable client 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-hbase-2.x</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0</version>
      </dependency>
 
     <!-- runtime dependencies -->

--- a/src/main/java/org/hbase/async/Bytes.java
+++ b/src/main/java/org/hbase/async/Bytes.java
@@ -26,12 +26,9 @@
  */
 package org.hbase.async;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.util.CharsetUtil;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import org.apache.hbase.thirdparty.io.netty.util.CharsetUtil;
+
 import java.util.*;
 
 /**

--- a/src/main/java/org/hbase/async/FilterComparator.java
+++ b/src/main/java/org/hbase/async/FilterComparator.java
@@ -27,8 +27,7 @@
 package org.hbase.async;
 
 import org.apache.hadoop.hbase.filter.ByteArrayComparable;
-
-import io.netty.buffer.ByteBuf;
+import org.apache.hbase.thirdparty.io.netty.buffer.ByteBuf;
 
 /**
  * Abstract base class for {@link ScanFilter} comparators.

--- a/src/main/java/org/hbase/async/KeyRegexpFilter.java
+++ b/src/main/java/org/hbase/async/KeyRegexpFilter.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.RegexStringComparator;
 import org.apache.hadoop.hbase.filter.RowFilter;
-import io.netty.util.CharsetUtil;
+import org.apache.hbase.thirdparty.io.netty.util.CharsetUtil;
 
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;

--- a/src/main/java/org/hbase/async/ScanFilter.java
+++ b/src/main/java/org/hbase/async/ScanFilter.java
@@ -28,8 +28,6 @@ package org.hbase.async;
 
 import org.apache.hadoop.hbase.filter.Filter;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * Abstract base class for {@link org.hbase.async.Scanner} filters.
  * <p>


### PR DESCRIPTION
Also, it looks like io.netty was removed from bigtable-hbase dependencies.  To mitigate that, use the hbase shaded version of netty instead of io.netty.