### PR TITLE
Add size method in FilterList to make it consistent with AsyncHBase

### DIFF
--- a/src/main/java/org/hbase/async/FilterList.java
+++ b/src/main/java/org/hbase/async/FilterList.java
@@ -94,6 +94,13 @@ public final class FilterList extends ScanFilter {
     this.op = op;
   }
 
+  /** @return the number of filters in the filter list
+   *  @since 1.8 */
+  public int size() {
+    // filter's can't be null here and shouldn't even be empty
+    return filters.size();
+  }
+
   @Override
   byte[] name() {
     return NAME;


### PR DESCRIPTION
Return the number of filters in the filter list

Fixes https://github.com/OpenTSDB/asyncbigtable/issues/54